### PR TITLE
fix for extension removing color scheme

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -15,9 +15,22 @@ class StatusBar {
     private item: vscode.StatusBarItem;
     timeout: NodeJS.Timer | null = null;
     counting = false;
+    userColorCustomizations: any;
+    gitDuckColorCustomizations: any;
 
     constructor() {
+        const statusBarFGColor = '#802525';
+        const statusBarBGColor = '#F85246';
         this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
+        this.userColorCustomizations = workbenchConfig.get('colorCustomizations');
+        this.gitDuckColorCustomizations = Object.assign(JSON.parse(JSON.stringify(this.userColorCustomizations)), {
+            'statusBar.background': statusBarBGColor,
+            'statusBar.foreground': statusBarFGColor,
+            'statusBar.debuggingForeground': statusBarFGColor,
+            'statusBar.debuggingBackground': statusBarBGColor,
+            'statusBar.noFolderForeground': statusBarFGColor,
+            'statusBar.noFolderBackground': statusBarBGColor,
+        });
     }
 
     show() {
@@ -40,7 +53,7 @@ class StatusBar {
     }
 
     stop() {
-        workbenchConfig.update('colorCustomizations', undefined, true);
+        workbenchConfig.update('colorCustomizations', JSON.parse(JSON.stringify(this.userColorCustomizations)), true);
         this.recordingStopped();
         this.item.command = 'gitduck.record';
         this.item.text = '$(triangle-right) Start GitDuck';
@@ -72,14 +85,7 @@ class StatusBar {
     start() {
         const statusBarFGColor = '#802525';
         const statusBarBGColor = '#F85246';
-        workbenchConfig.update('colorCustomizations', {
-            'statusBar.background': statusBarBGColor,
-            'statusBar.foreground': statusBarFGColor,
-            'statusBar.debuggingForeground': statusBarFGColor,
-            'statusBar.debuggingBackground': statusBarBGColor,
-            'statusBar.noFolderForeground': statusBarFGColor,
-            'statusBar.noFolderBackground': statusBarBGColor,
-        }, true);
+        workbenchConfig.update('colorCustomizations', this.gitDuckColorCustomizations, true);
         this.item.command = 'gitduck.stop';
         this.item.text = '$(primitive-square) GitDuck stream';
         this.item.color = '#000000';

--- a/src/status.ts
+++ b/src/status.ts
@@ -19,18 +19,7 @@ class StatusBar {
     gitDuckColorCustomizations: any;
 
     constructor() {
-        const statusBarFGColor = '#802525';
-        const statusBarBGColor = '#F85246';
         this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
-        this.userColorCustomizations = workbenchConfig.get('colorCustomizations');
-        this.gitDuckColorCustomizations = Object.assign(JSON.parse(JSON.stringify(this.userColorCustomizations)), {
-            'statusBar.background': statusBarBGColor,
-            'statusBar.foreground': statusBarFGColor,
-            'statusBar.debuggingForeground': statusBarFGColor,
-            'statusBar.debuggingBackground': statusBarBGColor,
-            'statusBar.noFolderForeground': statusBarFGColor,
-            'statusBar.noFolderBackground': statusBarBGColor,
-        });
     }
 
     show() {
@@ -85,7 +74,17 @@ class StatusBar {
     start() {
         const statusBarFGColor = '#802525';
         const statusBarBGColor = '#F85246';
-        workbenchConfig.update('colorCustomizations', this.gitDuckColorCustomizations, true);
+        this.userColorCustomizations = workbenchConfig.get('colorCustomizations');
+        this.gitDuckColorCustomizations = {
+            'statusBar.background': statusBarBGColor,
+            'statusBar.foreground': statusBarFGColor,
+            'statusBar.debuggingForeground': statusBarFGColor,
+            'statusBar.debuggingBackground': statusBarBGColor,
+            'statusBar.noFolderForeground': statusBarFGColor,
+            'statusBar.noFolderBackground': statusBarBGColor,
+        };        
+        const finalSettings = Object.assign({}, this.userColorCustomizations, this.gitDuckColorCustomizations)
+        workbenchConfig.update('colorCustomizations', finalSettings, true);
         this.item.command = 'gitduck.stop';
         this.item.text = '$(primitive-square) GitDuck stream';
         this.item.color = '#000000';

--- a/src/status.ts
+++ b/src/status.ts
@@ -20,6 +20,17 @@ class StatusBar {
 
     constructor() {
         this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right);
+        this.userColorCustomizations = workbenchConfig.get('colorCustomizations');
+        const statusBarFGColor = '#802525';
+        const statusBarBGColor = '#F85246';
+        this.gitDuckColorCustomizations = {
+            'statusBar.background': statusBarBGColor,
+            'statusBar.foreground': statusBarFGColor,
+            'statusBar.debuggingForeground': statusBarFGColor,
+            'statusBar.debuggingBackground': statusBarBGColor,
+            'statusBar.noFolderForeground': statusBarFGColor,
+            'statusBar.noFolderBackground': statusBarBGColor,
+        };
     }
 
     show() {
@@ -42,7 +53,7 @@ class StatusBar {
     }
 
     stop() {
-        workbenchConfig.update('colorCustomizations', JSON.parse(JSON.stringify(this.userColorCustomizations)), true);
+        workbenchConfig.update('colorCustomizations', this.userColorCustomizations, true);
         this.recordingStopped();
         this.item.command = 'gitduck.record';
         this.item.text = '$(triangle-right) Start GitDuck';
@@ -72,19 +83,9 @@ class StatusBar {
     }
 
     start() {
-        const statusBarFGColor = '#802525';
-        const statusBarBGColor = '#F85246';
         this.userColorCustomizations = workbenchConfig.get('colorCustomizations');
-        this.gitDuckColorCustomizations = {
-            'statusBar.background': statusBarBGColor,
-            'statusBar.foreground': statusBarFGColor,
-            'statusBar.debuggingForeground': statusBarFGColor,
-            'statusBar.debuggingBackground': statusBarBGColor,
-            'statusBar.noFolderForeground': statusBarFGColor,
-            'statusBar.noFolderBackground': statusBarBGColor,
-        };        
-        const finalSettings = Object.assign({}, this.userColorCustomizations, this.gitDuckColorCustomizations)
-        workbenchConfig.update('colorCustomizations', finalSettings, true);
+        const colorCustomizations = {...this.userColorCustomizations, ...this.gitDuckColorCustomizations};
+        workbenchConfig.update('colorCustomizations', colorCustomizations, true);
         this.item.command = 'gitduck.stop';
         this.item.text = '$(primitive-square) GitDuck stream';
         this.item.color = '#000000';


### PR DESCRIPTION
This pr fixes #2 

**Test PR**
1. debug the extension and set your default settings to the settings listed in #2 . 
2. start a git duck stream and notice that the users styles are still applied but the color of the status bar changes to indicate a live GitDuck Stream. 
3. Stop the gitduck stream and notice that the users color settings are reserved and set back to what they were. 
