### PR TITLE
Fix Copy  Bug on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
 	},
 	"dependencies": {
 		"@types/request-promise-native": "^1.0.17",
-		"clipboardy": "^2.1.0",
 		"fluent-ffmpeg": "^2.1.2",
 		"lodash": "^4.17.15",
 		"parse-diff": "^0.6.0",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import {getStore} from './store';
 import config from './config';
 import status from './status';
-import * as copyPaste from "clipboardy";
 
 export const authenticationCallback = (token: string, installationId: string) => {
     const store = getStore();
@@ -24,7 +23,7 @@ export const login = () => {
         `Please open this url in your browser so the extension can connect to your GitDuck account: ${URL}`,
         'Copy URL'
     ).then(() => {
-        copyPaste.writeSync(URL);
+        vscode.env.clipboard.writeText(URL);
     });
     vscode.env.openExternal(vscode.Uri.parse(URL));
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import recorder from './recorder';
 import status from './status';
 import {createCodingSession, completeSession, addCommits} from './api';
-import * as copyPaste from 'clipboardy';
 import config from './config';
 import {getStore, initStore} from './store';
 import {initCodeLinkingListener, getSessionCommits, cleanupCodeLinkingSession} from './code-linking';
@@ -56,7 +55,7 @@ export function activate(context: vscode.ExtensionContext) {
                     `Live coding session created: ${store.viewURL}`,
                     'Copy URL'
                 ).then(() => {
-                    copyPaste.writeSync(store.viewURL);
+                    vscode.env.clipboard.writeText(store.viewURL);
                 });
 
                 return status.start();
@@ -101,7 +100,7 @@ export function activate(context: vscode.ExtensionContext) {
                     `Uploading coding session to ${viewURL}`,
                     'Copy URL'
                 ).then(() => {
-                    copyPaste.writeSync(viewURL);
+                    vscode.env.clipboard.writeText(viewURL);
                 });
 
                 status.stop();


### PR DESCRIPTION
This PR fixes #4 

there was a bug when using the extension on windows that was preventing the user from copying the url of a session to the clipboard. 

This pr replaces a third-party module we were using for writing to the clipboard and allows us to use the vscode api directly to achieve the same result. 

**Testing**: 
Debug the extension, start a stream, click copy when vscode shows a notification to copy the url to your live stream, paste somewhere and notice it was copied. 